### PR TITLE
Fix unmounting on OSX

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -685,7 +685,7 @@ local function parse_sshfs_mounts(mount_output, root)
 		pattern = "^(.+)%son%s(" .. root_escaped .. "/.-)%s+type%s+fuse%.sshfs"
 	else
 		-- macOS: (macfuse or (osxfuse
-		pattern = "^(.+)%son%s(" .. root_escaped .. "/[^%s]+)%s+%(.*fuse"
+		pattern = "^(.+)%son%s(" .. root_escaped .. "/[^%s]+)%s+%(.*[mo][as][cx]fuse"
 	end
 
 	for line in mount_output:gmatch("[^\r\n]+") do


### PR DESCRIPTION
Thanks for this great plugin! I have had no problem mounting using the plugin but I encounter errors when trying to unmount. I believe this is an OSX issue.

Firstly, it did not detect the mounts, as the mount type is macfuse Not fuse.sshfs. E.g., 

    $mount
    ...
    SYSTEM: on ~/mnt/SYSTEM (**macfuse**, nodev, nosuid, synchronous, mounted by user)
    
Secondly, once I modified the regex to match correctly it did not unmount the identified system because the "-l" flag doesn't exist for umount on OSX.

    $umount -l ~/mnt/SYSTEM
    umount: illegal option -- l
    
I can unmount using `umount` with no flags or sometimes with `diskutil unmount` on OSX.