### PR TITLE
Fix: relocate saved hosts out of plugin configuration (issue #21)

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,36 @@
 A minimal, blazing fast <strong>SSHFS</strong> integration for the <a target="_blank" rel="noopener noreferrer" href="https://github.com/sxyazi/yazi">Yazi</a> terminal file‑manager.
 </p>
 
+<details>
+<summary>✨ What's New / 🚨 Breaking Changes</summary>
+<br/>
+<!-- whats-new:start -->
+
+  <details>
+    <summary>🚨 v2.0: Custom host file relocated (migration required)</summary>
+    <!-- v2.0:start -->
+    <h3>🚨 BREAKING CHANGE: <code>sshfs.list</code> relocated to follow XDG Base Directory spec</h3>
+    <p>
+      The custom hosts file has moved from <code>~/.config/yazi/sshfs.list</code> to
+      <code>$XDG_DATA_HOME/yazi/sshfs.list</code> (this is usually located in <code>~/.local/share/yazi/sshfs.list</code>).
+    </p>
+    <p><strong>If you have custom hosts saved, migrate your file before upgrading:</strong></p>
+    <pre>mv ~/.config/yazi/sshfs.list ~/.local/share/yazi/sshfs.list</pre>
+    <p>
+      If <code>$XDG_DATA_HOME</code> is set to a custom path, use that instead:
+    </p>
+    <pre>mv ~/.config/yazi/sshfs.list "$XDG_DATA_HOME/yazi/sshfs.list"</pre>
+    <p>
+      Hosts from <code>~/.ssh/config</code> are unaffected. Only manually added custom hosts need migration.
+      If you have no custom hosts then no action is needed.
+    </p>
+    <!-- v2.0:end -->
+
+  </details>
+
+<!-- whats-new:end -->
+</details>
+
 ## 🕶️ What does it do?
 
 Mount any host from your `~/.ssh/config`, or add custom hosts, and browse remote files as if they were local. Mount specific remote directories (like `/var/log` or `/etc`) or the entire home/root filesystem. Jump between your local machine and remote mounts with a single keystroke.

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Perfect for tweaking configs, deploying sites, inspecting logs, or just grabbing
 
 ## 🧠 What it does under the hood
 
-This plugin serves as a wrapper for the `sshfs` command, integrating it seamlessly with Yazi. It automatically reads hosts from your `~/.ssh/config` file. Additionally, it maintains a separate list of custom hosts which is by default stored in `$XDG_DATA_HOME/yazi/sshfs.list`, or if `$XDG_DATA_HOME` is note defined, in `~/.local/share/yazi/sshfs.list`.
+This plugin serves as a wrapper for the `sshfs` command, integrating it seamlessly with Yazi. It automatically reads hosts from your `~/.ssh/config` file. Additionally, it maintains a separate list of custom hosts which is by default stored in `$XDG_DATA_HOME/yazi/sshfs.list` (or in `~/.local/share/yazi/sshfs.list` if `$XDG_DATA_HOME` is not defined).
 
 The core default `sshfs` command used is as follows (you may tweak these options and the mount directory with your setup settings):
 

--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ The `M s` menu provides access to all SSHFS functions:
 - `r` → Remove host
 - `h` → Go to mount home
 - `c` → Open ~/.ssh/config
+- `l` → Open custom host list
 
 > [!TIP]
 > `sshfs.yazi` uses the [array form for keymaps](https://yazi-rs.github.io/docs/configuration/keymap).
@@ -189,6 +190,7 @@ prepend_keymap = [
   { on = ["M","r"], run = "plugin sshfs -- remove",          desc = "Remove SSH host" },
   { on = ["M","h"], run = "plugin sshfs -- home",            desc = "Go to mount home" },
   { on = ["M","c"], run = "cd ~/.ssh/",                      desc = "Go to ssh config" },
+  { on = ["M","l"], run = "plugin sshfs -- hosts",           desc = "Open custom host list" },
 ]
 ```
 
@@ -206,6 +208,7 @@ prepend_keymap = [
   - **Add host (`M a`):** Enter a custom host (`user@host`) and optionally specify a remote directory (e.g., `/var/log`, `/etc/nginx`) to create an alias for that specific path. When you mount this alias later, it will go directly to that remote directory. This is useful for frequently accessed remote directories or quick testing. For persistent, system-wide access, updating your `.ssh/config` is recommended.
   - **Remove host (`M r`):** Select and remove any Yazi-only hosts that you've added.
   - **Jump to mount home directory (`M h`):** Jump to the mount home directory.
+  - **Open custom host list (`M l`):** Navigate to the directory containing your custom hosts file for direct editing.
 
 ## 💡 Tips and Performance
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Perfect for tweaking configs, deploying sites, inspecting logs, or just grabbing
 
 ## 🧠 What it does under the hood
 
-This plugin serves as a wrapper for the `sshfs` command, integrating it seamlessly with Yazi. It automatically reads hosts from your `~/.ssh/config` file. Additionally, it maintains a separate list of custom hosts in `~/.config/yazi/sshfs.list`.
+This plugin serves as a wrapper for the `sshfs` command, integrating it seamlessly with Yazi. It automatically reads hosts from your `~/.ssh/config` file. Additionally, it maintains a separate list of custom hosts which is by default stored in `$XDG_DATA_HOME/yazi/sshfs.list`, or if `$XDG_DATA_HOME` is note defined, in `~/.local/share/yazi/sshfs.list`.
 
 The core default `sshfs` command used is as follows (you may tweak these options and the mount directory with your setup settings):
 
@@ -194,6 +194,9 @@ To customize plugin behavior, you may pass a config table to `setup()` (default 
 
 ```lua
 require("sshfs"):setup({
+  -- Custom hosts file
+  custom_hosts_file = (os.getenv("XDG_DATA_HOME") or ("~/.local/share")) .. "/yazi/sshfs.list",
+
   -- Mount directory
   mount_dir = os.getenv("HOME") .. "/mnt",
 

--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ To customize plugin behavior, you may pass a config table to `setup()` (default 
 ```lua
 require("sshfs"):setup({
   -- Custom hosts file
-  custom_hosts_file = (os.getenv("XDG_DATA_HOME") or ("~/.local/share")) .. "/yazi/sshfs.list",
+  custom_hosts_file = (os.getenv("XDG_DATA_HOME") or (os.getenv("HOME") .. "/.local/share")) .. "/yazi/sshfs.list",
 
   -- Mount directory
   mount_dir = os.getenv("HOME") .. "/mnt",

--- a/main.lua
+++ b/main.lua
@@ -1212,6 +1212,12 @@ local function cmd_open_ssh_config()
   ya.emit("cd", { HOME .. "/.ssh/", raw = true })
 end
 
+local function cmd_open_custom_hosts()
+  local config = get_state(STATE_KEY.CONFIG)
+  local parent = config.custom_hosts_file:match("^(.+)/[^/]+$")
+  ya.emit("cd", { parent, raw = true })
+end
+
 local function cmd_menu()
   local choice = ya.which({
     title = "SSHFS Menu",
@@ -1222,6 +1228,7 @@ local function cmd_menu()
       { on = "r", desc = "Remove host" },
       { on = "h", desc = "Go to mount home" },
       { on = "c", desc = "Open ~/.ssh/config" },
+      { on = "l", desc = "Open custom host list" },
     },
   })
 
@@ -1237,6 +1244,8 @@ local function cmd_menu()
     cmd_open_mount_dir()
   elseif choice == 6 then
     cmd_open_ssh_config()
+  elseif choice == 7 then
+    cmd_open_custom_hosts()
   end
 end
 
@@ -1339,6 +1348,8 @@ function M:entry(job)
     cmd_open_mount_dir()
   elseif action == "menu" then
     cmd_menu()
+  elseif action == "hosts" then
+    cmd_open_custom_hosts()
   else
     Notify.error("Unknown action")
   end

--- a/main.lua
+++ b/main.lua
@@ -11,8 +11,7 @@ local XDG_RUNTIME_DIR = os.getenv("XDG_RUNTIME_DIR") or ("/run/user/" .. USER_ID
 --=========== Paths ===========================================================
 local HOME = os.getenv("HOME")
 local SSH_CONFIG = HOME .. "/.ssh/config"
-local YAZI_DIR = HOME .. "/.config/yazi"
-local SAVE_LIST = YAZI_DIR .. "/sshfs.list" -- list of remembered aliases
+local XDG_DATA_HOME = os.getenv("XDG_DATA_HOME") or (HOME .. "/.local/share")
 
 --=========== Plugin State ===========================================================
 ---@enum
@@ -569,10 +568,11 @@ end
 
 --============== Cache state management ====================================
 ---Check if host cache is valid by comparing file modification times
+---@param hosts_filename string
 ---@return boolean
-local function is_host_cache_valid()
+local function is_host_cache_valid(hosts_filename)
   local ssh_config_mtime = get_file_mtime(SSH_CONFIG)
-  local save_file_mtime = get_file_mtime(SAVE_LIST)
+  local save_file_mtime = get_file_mtime(hosts_filename)
 
   return (
     host_cache.hosts ~= nil
@@ -583,9 +583,10 @@ end
 
 ---Update host cache with current file modification times
 ---@param hosts string[]
-local function update_host_cache(hosts)
+---@param hosts_filename string
+local function update_host_cache(hosts, hosts_filename)
   local ssh_config_mtime = get_file_mtime(SSH_CONFIG)
-  local save_file_mtime = get_file_mtime(SAVE_LIST)
+  local save_file_mtime = get_file_mtime(hosts_filename)
 
   host_cache.hosts = hosts
   host_cache.ssh_config_mtime = ssh_config_mtime
@@ -593,27 +594,28 @@ local function update_host_cache(hosts)
 end
 
 ---Get list of all available hosts (from SSH config and custom list)
+---@param hosts_filename string
 ---@return string[]
-local function get_all_hosts()
-  if is_host_cache_valid() then return host_cache.hosts end
+local function get_all_hosts(hosts_filename)
+  if is_host_cache_valid(hosts_filename) then return host_cache.hosts end
 
   local ssh_config_hosts = read_ssh_config_hosts()
   local hosts
 
   -- Check if custom hosts file exists
-  local url = Url(SAVE_LIST)
+  local url = Url(hosts_filename)
   local cha, _ = fs.cha(url)
 
   if cha then
     -- Custom hosts file exists - combine SSH config and saved hosts
-    local saved_hosts = read_lines(SAVE_LIST)
+    local saved_hosts = read_lines(hosts_filename)
     hosts = unique(list_extend(saved_hosts, ssh_config_hosts))
   else
     -- No custom hosts file - only use SSH config
     hosts = ssh_config_hosts
   end
 
-  update_host_cache(hosts)
+  update_host_cache(hosts, hosts_filename)
   return hosts
 end
 
@@ -984,8 +986,8 @@ local function add_mountpoint(entry, jump)
   fs.remove("dir_clean", mountUrl) -- clean empty dir
 end
 
-local function check_alias_exists(alias)
-  for _, saved_alias in ipairs(read_lines(SAVE_LIST)) do
+local function check_alias_exists(alias, hosts_filename)
+  for _, saved_alias in ipairs(read_lines(hosts_filename)) do
     if saved_alias == alias then return true end
   end
   return false
@@ -1035,13 +1037,14 @@ end
 
 --=========== api actions =================================================
 local function cmd_add_alias()
+  local config = get_state(STATE_KEY.CONFIG)
   local host = prompt("Enter SSH host:")
   if host == nil then
     return false
   elseif not host:match("^[%w_.%-@]+:?[%w%-%.]*$") then
     Notify.error("Host must be a valid SSH host string")
     return
-  elseif check_alias_exists(host) then
+  elseif check_alias_exists(host, config.custom_hosts_file) then
     Notify.warn("Host already exists")
     return
   end
@@ -1062,12 +1065,12 @@ local function cmd_add_alias()
   end
 
   -- Check if the full alias (with path) already exists
-  if check_alias_exists(alias) then
+  if check_alias_exists(alias, config.custom_hosts_file) then
     Notify.warn("Host alias already exists")
     return
   end
 
-  append_line(SAVE_LIST, alias)
+  append_line(config.custom_hosts_file, alias)
   debug("Saved host alias `%s`", alias)
 
   -- Update cache
@@ -1082,15 +1085,16 @@ local function cmd_add_alias()
     end
     if not found then table.insert(host_cache.hosts, alias) end
     -- Update the save file mtime
-    host_cache.save_file_mtime = get_file_mtime(SAVE_LIST)
+    host_cache.save_file_mtime = get_file_mtime(config.custom_hosts_file)
   end
 
   Notify.info(("Added %s to custom hosts"):format(alias))
 end
 
 local function cmd_remove_alias()
+  local config = get_state(STATE_KEY.CONFIG)
   -- Check if custom hosts file exists
-  local url = Url(SAVE_LIST)
+  local url = Url(config.custom_hosts_file)
   local cha, _ = fs.cha(url)
 
   if not cha then
@@ -1100,7 +1104,7 @@ local function cmd_remove_alias()
 
   -- Choose from saved aliases
   local config = get_state(STATE_KEY.CONFIG)
-  local saved_aliases = read_lines(SAVE_LIST)
+  local saved_aliases = read_lines(config.custom_hosts_file)
   local alias = choose("Remove which?", saved_aliases, config)
   if not alias then return end
 
@@ -1116,7 +1120,7 @@ local function cmd_remove_alias()
     debug("Deleted empty custom hosts file")
   else
     -- Overwrite the save list file with updated lines
-    local file, err = io.open(SAVE_LIST, "w")
+    local file, err = io.open(config.custom_hosts_file, "w")
     if not file then
       Notify.error("Failed to open save file: %s", tostring(err))
       return
@@ -1136,7 +1140,7 @@ local function cmd_remove_alias()
     end
     host_cache.hosts = new_hosts
     -- Update the save file mtime
-    host_cache.save_file_mtime = get_file_mtime(SAVE_LIST)
+    host_cache.save_file_mtime = get_file_mtime(config.custom_hosts_file)
   end
 
   Notify.info(("Alias “%s” removed from saved list"):format(alias))
@@ -1146,7 +1150,7 @@ local function cmd_mount(args)
   local config = get_state(STATE_KEY.CONFIG)
   -- Get alias_list
   local jump = args.jump == true
-  local alias_list = get_all_hosts()
+  local alias_list = get_all_hosts(config.custom_hosts_file)
   -- Choose alias to mount then add it
   local chosen_alias = (#alias_list == 1) and alias_list[1] or choose("Mount which host?", alias_list, config)
   if chosen_alias then add_mountpoint(chosen_alias, jump) end
@@ -1282,6 +1286,7 @@ end
 --=========== Plugin start =================================================
 -- Default configuration
 local default_config = {
+  custom_hosts_file = XDG_DATA_HOME .. "/yazi/sshfs.list", -- list of remembered aliases
   mount_dir = HOME .. "/mnt",
   password_attempts = 3, -- Number of password attempts before giving up
   default_mount_point = "auto",

--- a/main.lua
+++ b/main.lua
@@ -1315,6 +1315,9 @@ end
 ---Setup
 function M:setup(cfg)
   set_plugin_config(cfg)
+  local config = get_state(STATE_KEY.CONFIG)
+  local parent = config.custom_hosts_file:match("^(.+)/[^/]+$")
+  if parent then ensure_dir(Url(parent)) end
 end
 
 ---Entry


### PR DESCRIPTION
This PR resolves issue #21 by replacing the `SAVE_LIST` variable with a config parameter `custom_hosts_file`, which defaults to `$XDG_DATA_HOME/yazi/sshfs.list` or `~/.local/share/sshfs.list` if `$XDG_DATA_HOME` is not defined.

I tested adding an alias, mounting the alias, unmounting the alias, and removing the alias with `$XDG_DATA_HOME` set, `$XDG_DATA_HOME` unset, and with a custom value for `custom_hosts_file`. All these cases worked as expected.

I only tested with key-based authentication on hosts I had readily available. I suppose this should be enough given the scope of the changes.

Worth noting that this change means that existing users of the plugin will have to either change the value of `custom_hosts_file` back to the old value or migrate their `sshfs.list` into the appropriate directory to preserve their saved aliases.